### PR TITLE
Add more verbose output

### DIFF
--- a/kubectl-capture
+++ b/kubectl-capture
@@ -11,6 +11,7 @@ now=$(date +%s)
 capture_pod=""
 sysdig_params=""
 ebpf="0"
+verborse="0"
 
 function main() {
   parse_arguments "$@"
@@ -34,6 +35,9 @@ function parse_arguments() {
         ;;
       --ebpf)
         ebpf="1"
+        ;;
+      -v)
+        verbose="1"
         ;;
       -w|--write=*|-z|--compress|-pc|-pk|-pm|-print=*|-S|--summary)
         # Do not allow changes on these parameters
@@ -64,12 +68,18 @@ Usage: kubectl capture POD [-ns NAMESPACE] [sysdig options]
 Options:
   -ns | --namespace   The namespace where the target pod lives (default: default)
   --ebpf              Launch capture pod with eBPF probe instead of kernel module
+  -v                  Set verbose option to follow the whole process
 EOF
   exit $1
 }
 
 function start_capture() {
-  node=$(kubectl -n ${namespace} get pod ${pod} -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+  if [[ "${verbose}" -eq "1" ]];then
+    node=$(kubectl -n ${namespace} get pod ${pod} -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+  else
+    node=$(kubectl -n ${namespace} get pod ${pod} -o jsonpath='{.spec.nodeName}')
+  fi
+
   if [[ $? -ne 0 ]];then
     echo "error: Unable to trigger a capture on pod ${pod}"
     exit 1
@@ -81,7 +91,12 @@ function start_capture() {
     build_capture_pod
   fi
 
-  kubectl apply -f capture-pod.yaml > /dev/null 2>&1
+  if [[ "${verbose}" -eq "1" ]];then
+    kubectl apply -f capture-pod.yaml
+  else
+    kubectl apply -f capture-pod.yaml > /dev/null 2>&1
+  fi
+
   rm capture-pod.yaml
 
   echo "Sysdig is starting to capture system calls:"
@@ -94,10 +109,22 @@ function start_capture() {
 
   wait_until_finished
 
-  kubectl cp ${capture_pod}:/${capture_pod}.scap.gz ${capture_pod}.scap.gz > /dev/null 2>&1
-  kubectl delete pod ${capture_pod} > /dev/null 2>&1
-  echo "The capture has been downloaded to your hard disk at:"
-  echo "${PWD}/${capture_pod}.scap.gz"
+
+  if [[ "${verbose}" -eq "1" ]];then
+    kubectl logs ${capture_pod}
+    kubectl cp ${capture_pod}:/${capture_pod}.scap.gz ${capture_pod}.scap.gz
+    kubectl delete pod ${capture_pod}
+  else
+    kubectl cp ${capture_pod}:/${capture_pod}.scap.gz ${capture_pod}.scap.gz > /dev/null 2>&1
+    kubectl delete pod ${capture_pod} > /dev/null 2>&1
+  fi
+
+  if [[ -f "${PWD}/${capture_pod}.scap.gz" ]]; then
+    echo "The capture has been downloaded to your hard disk at:"
+    echo "${PWD}/${capture_pod}.scap.gz"
+  else
+    echo "Error capturing, file not created. Try with the verbose option(-v) to have get more info."
+  fi
 }
 
 function build_capture_pod() {
@@ -265,7 +292,13 @@ function delete_capture_pod() {
   if [[ -n "${capture_pod}" ]]; then
     echo ""
     echo "Please wait until capture pod is deleted"
-    kubectl delete pod ${capture_pod} > /dev/null 2>&1
+
+    if [[ "${verbose}" -eq "1" ]];then
+      kubectl delete pod ${capture_pod}
+    else
+      kubectl delete pod ${capture_pod} > /dev/null 2>&1
+    fi
+
   fi
   exit 0
 }


### PR DESCRIPTION
I found kubectl-capture really useful but sometimes I had some difficulties to get some information about why it doesn´t create the capture file.

This PR creates:
- Add option -v to show what is happening in the process to scrap data.
- When verbose option is set. Commands are executed without omitting output and getting logs from the capture pod.
- Final output don´t say that a file is created if it does not exist.

@nestorsalceda Let me know how do you feel about this option.

Example:

`kubectl capture net-exporter-4p7ls  -ns kube-system  --ebpf -v -M 10 --snaplen 256
`
```
pod/capture-net-exporter-4p7ls-1558943294 created
Sysdig is starting to capture system calls:

Node: master-qomd3-84d58bd6fb-vsfsm
Pod: net-exporter-4p7ls
Duration: 10 seconds
Parameters for Sysdig: -S -M 10 -pk -z -w /capture-net-exporter-4p7ls-1558943294.scap.gz  --snaplen 256

* Setting up /usr/src links from host
ls: cannot access '/host/usr/src': No such file or directory
* Mounting debugfs
Found kernel config at /proc/config.gz
* Trying to compile BPF probe sysdig-probe-bpf (sysdig-probe-bpf-0.26.0-x86_64-4.19.23-coreos-r1-03bf994bd8b87756106f34511fc1aadb.o)
* BPF probe located, it's now possible to start sysdig
* Capturing system calls
* Mounting debugfs
Found kernel config at /proc/config.gz
* BPF probe located, it's now possible to start sysdig
mmap (2): Cannot allocate memory
----------------------
Event           #Calls
----------------------
tar: Removing leading `/' from member names
tar: /capture-net-exporter-4p7ls-1558943294.scap.gz: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
error: capture-net-exporter-4p7ls-1558943294.scap.gz no such file or directory
pod "capture-net-exporter-4p7ls-1558943294" deleted
Error capturing, file not created. Try with the verbose option(-v) to have get more info.
```
